### PR TITLE
Add development server file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,14 +7,15 @@ default:
 	# renames the raw HTML
 	mv output/2017.02.18_Final.html \
 		output/raw_index.html
-	# parses the raw HTML & rerenders the templates 
+	# parses the raw HTML & rerenders the templates
 	python main.py
 
+server:
+	python server.py
 
 install:
 	npm install
 	pip install -r ./requirements.txt
-
 
 deploy:
 	git subtree push --prefix output origin gh-pages

--- a/README.md
+++ b/README.md
@@ -58,6 +58,16 @@ make
 
 This will produce an output similar to [what is described here](https://github.com/rootandrebound/roadmap-to-html/issues/1).
 
+### 5. View the HTML locally
+
+You can view the HTML locally by running:
+
+```bash
+make server
+```
+
+and then opening http://0.0.0.0:8080 in your browser.
+
 ### The script
 
 The Makefile includes one command for producing the HTML output:

--- a/server.py
+++ b/server.py
@@ -1,0 +1,28 @@
+from http.server import HTTPServer, SimpleHTTPRequestHandler
+import os
+
+class RewritingHTTPRequestHandler(SimpleHTTPRequestHandler):
+    """
+    Serve responses but from /output/<filename> instead of /roadmap-to-html/<filename>
+    """
+    def translate_path(self, path):
+        path = super(self.__class__, self).translate_path(path)
+
+        # remove the filesystem path up to this file
+        path = path.replace(os.path.dirname(os.path.realpath(__file__)), "")
+
+        # then replace the beginning /roadmap-to-html/<filename> with
+        # /output/<filename>
+        path = path.replace("/roadmap-to-html/", "/output/")
+
+        # reappend the OS path since it's needed by the server
+        path = os.path.dirname(os.path.realpath(__file__)) + path
+        return path
+
+def run(server_class=HTTPServer, handler_class=RewritingHTTPRequestHandler):
+    server_address = ('', 8000)
+    httpd = server_class(server_address, handler_class)
+    print("Listening on 0.0.0.0 Port 8000")
+    httpd.serve_forever()
+
+run()


### PR DESCRIPTION
This adds a simple HTTP server, server.py, that can be used for local
development by running `make server` or just `python server.py`.

This has to rewrite the URLs to maintain compatibility with the GH pages
folder structure.