### PR TITLE
Charts and tables look bad #36

### DIFF
--- a/output/css/style.css
+++ b/output/css/style.css
@@ -54,7 +54,65 @@ p {
   padding: 1em 0;
 }
 
+/* TABLES */
+table {
+  border-collapse: collapse;
+  text-transform: lowercase;
+  width: 100%;
+}
 
+table p::first-letter {
+  text-transform: uppercase;
+}
+
+table p {
+  margin: 0;
+  padding: 0.5em 0;
+}
+
+th {
+  background-color: #f4f4f4;
+  font-weight: bold;
+}
+th,
+td {
+  background-color: #f9f9f9;
+  border: 0.05em solid #ddd;
+  line-height: 1.5;
+  padding: 0.5em;
+  text-align: left;
+  vertical-align: top;
+}
+
+/* Stack rows vertically on small screens */
+@media screen and (max-width: 900px) {
+
+  /* Hide column headers */
+	thead tr {
+		position: absolute;
+		top: -9999em;
+		left: -9999em;
+	}
+	tr {
+    border: 0.125em solid #ddd;;
+    border-bottom: 0;
+  }
+
+	/* Add a space between table rows */
+  tr + tr {
+    margin-top: 1.5em;
+  }
+
+  /* Table cells to act like rows */
+  tr,
+  td {
+		display: block;
+	}
+	td {
+		border: none;
+		border-bottom: 0.125em solid #ddd;
+	}
+}
 
 ul.footer-links {
   padding: 0; margin: 0;

--- a/output/css/style.css
+++ b/output/css/style.css
@@ -74,8 +74,7 @@ th {
   background-color: #f4f4f4;
   font-weight: bold;
 }
-th,
-td {
+th, td {
   background-color: #f9f9f9;
   border: 0.05em solid #ddd;
   line-height: 1.5;
@@ -98,14 +97,13 @@ td {
     border-bottom: 0;
   }
 
-	/* Add a space between table rows */
+  /* Add a space between table rows */
   tr + tr {
     margin-top: 1.5em;
   }
 
   /* Table cells to act like rows */
-  tr,
-  td {
+  tr, td {
 		display: block;
 	}
 	td {


### PR DESCRIPTION
Adds basic styling to tables across the site. 
![image](https://user-images.githubusercontent.com/4028371/30576244-7a36a068-9cbb-11e7-8b7d-21defb4a2abf.png)

Make cells stack on mobile devices to enhance readability.
![image](https://user-images.githubusercontent.com/4028371/30576263-98483c1a-9cbb-11e7-89aa-ce15879a2e07.png)

Some of the stylings include
- Normalize as much as possible text and capitalization in the cells.
- Left align text in the cells and vertical align it to the top.

I tried about 10 tables and they all look fine. Since there are more than 200 <table> tags in the html files there will probably be some bugs to fix. 